### PR TITLE
 code to assign port from environment variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const fs = require('fs');
 const { pathToFileURL } = require('url');
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000; // for better approch, use environment valiable to ensure if 3000 is busy then server can assign any free port , it is neccissary for production
 
 //Using middleware
 app.use(express.json());


### PR DESCRIPTION
Environment variables must be used to assign port to server , although it doesn't affect on local machine , but once the server is online then it is very rare that port 3000 ( or any port hard coded) is free, so its better to use or statement . 
Thank You ! : )  